### PR TITLE
Update the value type of UGCText.attributes

### DIFF
--- a/src/LinkedInApiV2.xml
+++ b/src/LinkedInApiV2.xml
@@ -629,13 +629,32 @@
     </ReturnType>
 
     <ReturnType Name="UGCText" ClassName="UGCText">
-      <Field Name="attributes" IsCollection="1" />
+      <Field Name="attributes" Type="UGCAnnotations" IsCollection="1" />
       <Field Name="text" />
     </ReturnType>
 
     <ReturnType Name="UGCText" ClassName="UGCGetText">
-      <Field Name="attributes" Type="object" IsCollection="1" />
+      <Field Name="attributes" Type="UGCAnnotations" IsCollection="1" />
       <Field Name="text" />
+    </ReturnType>
+    
+    <ReturnType Name="UGCAnnotations" ClassName="UGCAnnotations">
+      <Field Name="value" Type="valueAnnotation"/>
+      <Field Name="length" Type="int" />
+      <Field Name="start" Type="int" />
+    </ReturnType>
+
+    <ReturnType Name="valueAnnotation" ClassName="valueAnnotation">
+      <Field Name="com.linkedin.common.CompanyAttributedEntity" PropertyName="CompanyAttributedEntity" Type="CompanyAttributedEntity" />
+      <Field Name="com.linkedin.common.MemberAttributedEntity" PropertyName="MemberAttributedEntity" Type="MemberAttributedEntity" />
+    </ReturnType>
+
+    <ReturnType Name="CompanyAttributedEntity" ClassName="CompanyAttributedEntity">
+      <Field Name="company"/>
+    </ReturnType>
+
+    <ReturnType Name="MemberAttributedEntity" ClassName="MemberAttributedEntity">
+      <Field Name="member"/>
     </ReturnType>
 
     <ReturnType Name="LandingPage" ClassName="LandingPage">


### PR DESCRIPTION
Update the value type of UGCText.attributes from String to UGC Mentions according to the documentation:

https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api#mentions-in-ugc-posts

New Structure:

"attributes": [
                    {
                        "length": 9,
                        "start": 6,
                        "value": {
                            "com.linkedin.common.CompanyAttributedEntity": {
                                "company": "urn:li:organization:1234"
                            }
                        }
                    }
                ],