### PR TITLE
Library is not compatible with .NETCore due to using SecurityProtocolType.Ssl3 in BaseApi, BaseApi.Async ServicePointManager

### DIFF
--- a/src/Sparkle.LinkedInNET/Internals/BaseApi.Async.cs
+++ b/src/Sparkle.LinkedInNET/Internals/BaseApi.Async.cs
@@ -19,7 +19,7 @@ namespace Sparkle.LinkedInNET.Internals
     {
         internal async Task<bool> ExecuteQueryAsync(RequestContext context, bool? useRestliProtocol = false)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
             // https://developer.linkedin.com/documents/request-and-response-headers
 

--- a/src/Sparkle.LinkedInNET/Internals/BaseApi.cs
+++ b/src/Sparkle.LinkedInNET/Internals/BaseApi.cs
@@ -146,7 +146,7 @@ namespace Sparkle.LinkedInNET.Internals
         internal bool ExecuteQuery(RequestContext context, bool? useRestliProtocol = false)
         {
 
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
             // https://developer.linkedin.com/documents/request-and-response-headers
 


### PR DESCRIPTION
Removed SecurityProtocolType.Ssl3 from BaseApi & BaseApi.Async ServicePointManager so the library is usable in .NET Core