### PR TITLE
Update OAuth2Api.Async.cs to fix error code 411

### DIFF
--- a/src/Sparkle.LinkedInNET/OAuth2/OAuth2Api.Async.cs
+++ b/src/Sparkle.LinkedInNET/OAuth2/OAuth2Api.Async.cs
@@ -64,6 +64,7 @@ namespace Sparkle.LinkedInNET.OAuth2
             var bytes = Encoding.UTF8.GetBytes(json);
 
             context.RequestHeaders.Add("x-li-format", "json");
+            context.RequestHeaders.Add("content-length", "0");
             context.PostDataType = "application/json";
             context.PostData = bytes;
             #endregion

--- a/src/Sparkle.LinkedInNET/OAuth2/OAuth2Api.cs
+++ b/src/Sparkle.LinkedInNET/OAuth2/OAuth2Api.cs
@@ -106,6 +106,7 @@ namespace Sparkle.LinkedInNET.OAuth2
                 Method= "POST",
                 UrlPath = url,
             };
+            context.RequestHeaders.Add("content-length", "0");
             this.ExecuteQuery(context);
 
             AuthorizationAccessToken result = null;


### PR DESCRIPTION
"Please make sure POST requests with an empty body have a Content-Length header specified."

According to this:
https://docs.microsoft.com/en-us/linkedin/shared/api-guide/concepts/error-handling#411-length-required

Right now the library constantly receives an error:
```
HTTP/1.1 411 Length Required
Content-Type: text/html; charset=us-ascii
Date: Wed, 13 May 2020 10:24:47 GMT
Connection: close
Content-Length: 344

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
<HTML><HEAD><TITLE>Length Required</TITLE>
<META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
<BODY><h2>Length Required</h2>
<hr><p>HTTP Error 411. The request must be chunked or have a content length.</p>
</BODY></HTML>
```

This should fix that error from happening.